### PR TITLE
Link to allauth pages and add styling

### DIFF
--- a/how_to_hold_a_grudge/settings.py
+++ b/how_to_hold_a_grudge/settings.py
@@ -64,7 +64,7 @@ ROOT_URLCONF = "how_to_hold_a_grudge.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -139,3 +139,5 @@ AUTHENTICATION_BACKENDS = [
     # `allauth` specific authentication methods, such as login by email
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
+
+LOGIN_REDIRECT_URL = "/"

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% load allauth account %}
+
+{% block title %}Sign In{% endblock %}
+
+{% block content %}
+    {% element h1 %}
+        Sign In
+    {% endelement %}
+    {% if not SOCIALACCOUNT_ONLY %}
+        {% setvar link %}
+            <a href="{{ signup_url }}">
+            {% endsetvar %}
+            {% setvar end_link %}
+            </a>
+        {% endsetvar %}
+        {% element p %}
+            If you have not created an account yet, then please {{ link }}sign up{{ end_link }} first.
+        {% endelement %}
+        {% url 'account_login' as login_url %}
+        {% element form form=form method="post" action=login_url tags="entrance,login" %}
+            {% slot body %}
+                {% csrf_token %}
+                {% element fields form=form unlabeled=True %}
+                {% endelement %}
+                {{ redirect_field }}
+            {% endslot %}
+            {% slot actions %}
+                {% element button type="submit" tags="prominent,login" %}
+                    Sign In
+                {% endelement %}
+            {% endslot %}
+        {% endelement %}
+    {% endif %}
+    {% if LOGIN_BY_CODE_ENABLED or PASSKEY_LOGIN_ENABLED %}
+        {% element hr %}
+        {% endelement %}
+        {% element button_group vertical=True %}
+            {% if PASSKEY_LOGIN_ENABLED %}
+                {% element button type="submit" form="mfa_login" id="passkey_login" tags="prominent,login,outline,primary" %}
+                    Sign in with a passkey
+                {% endelement %}
+            {% endif %}
+            {% if LOGIN_BY_CODE_ENABLED %}
+                {% element button href=request_login_code_url tags="prominent,login,outline,primary" %}
+                    Mail me a sign-in code
+                {% endelement %}
+            {% endif %}
+        {% endelement %}
+    {% endif %}
+    {% if SOCIALACCOUNT_ENABLED %}
+        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+    {% endif %}
+{% endblock content %}
+
+{% block extra_body %}
+    {{ block.super }}
+    {% if PASSKEY_LOGIN_ENABLED %}
+        {% include "mfa/webauthn/snippets/login_script.html" with button_id="passkey_login" %}
+    {% endif %}
+{% endblock %}

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load allauth i18n %}
+
+{% block title %}Sign Out{% endblock %}
+
+{% block content %}
+    {% element h1 %}
+        Sign Out
+    {% endelement %}
+    {% element p %}
+        Are you sure you want to sign out?
+    {% endelement %}
+    {% url 'account_logout' as action_url %}
+    {% element form method="post" action=action_url no_visible_fields=True %}
+        {% slot body %}
+            {% csrf_token %}
+            {{ redirect_field }}
+        {% endslot %}
+        {% slot actions %}
+            {% element button type="submit" %}
+                Sign Out
+            {% endelement %}
+        {% endslot %}
+    {% endelement %}
+{% endblock content %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% load allauth account %}
+
+{% block title %}Password Reset{% endblock %}
+
+{% block content %}
+    {% element h1 %}
+        Password Reset
+    {% endelement %}
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+    {% element p %}
+        Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it.
+    {% endelement %}
+    {% url 'account_reset_password' as reset_url %}
+    {% element form form=form method="post" action=reset_url %}
+        {% slot body %}
+            {% csrf_token %}
+            {% element fields form=form %}
+            {% endelement %}
+        {% endslot %}
+        {% slot actions %}
+            {% element button type="submit" %}
+                Reset My Password
+            {% endelement %}
+        {% endslot %}
+    {% endelement %}
+    {% element p %}
+        Please contact us if you have any trouble resetting your password.
+    {% endelement %}
+{% endblock content %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% load allauth %}
+
+{% block title %}Sign Up{% endblock %}
+
+{% block content %}
+    {% element h1 %}
+        Sign Up
+    {% endelement %}
+    {% setvar link %}
+        <a href="{{ login_url }}">
+        {% endsetvar %}
+        {% setvar end_link %}
+        </a>
+    {% endsetvar %}
+    {% element p %}
+        Already have an account? Then please {{ link }}sign in{{ end_link }}.
+    {% endelement %}
+    {% if not SOCIALACCOUNT_ONLY %}
+        {% url 'account_signup' as action_url %}
+        {% element form form=form method="post" action=action_url tags="entrance,signup" %}
+            {% slot body %}
+                {% csrf_token %}
+                {% element fields form=form unlabeled=True %}
+                {% endelement %}
+                {{ redirect_field }}
+            {% endslot %}
+            {% slot actions %}
+                {% element button tags="prominent,signup" type="submit" %}
+                    Sign Up
+                {% endelement %}
+            {% endslot %}
+        {% endelement %}
+    {% endif %}
+    {% if SOCIALACCOUNT_ENABLED %}
+        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+    {% endif %}
+{% endblock content %}

--- a/templates/allauth/elements/alert.html
+++ b/templates/allauth/elements/alert.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<div class="alert alert-xs {% if attrs.level == "error" %}alert-warning{% else %}alert-info{% endif %}">
+    {% slot message %}
+    {% endslot %}
+</div>

--- a/templates/allauth/elements/badge.html
+++ b/templates/allauth/elements/badge.html
@@ -1,0 +1,19 @@
+{% load allauth %}
+{% setvar variant %}
+    {% if "warning" in attrs.tags %}
+        warning
+    {% elif "danger" in attrs.tags %}
+        danger
+    {% elif "secondary" in attrs.tags %}
+        secondary
+    {% elif "success" in attrs.tags %}
+        success
+    {% else %}
+        primary
+    {% endif %}
+{% endsetvar %}
+<span {% if attrs.title %}title="{{ attrs.title }}"{% endif %}
+      class="badge text-bg-{{ variant }}">
+    {% slot %}
+    {% endslot %}
+</span>

--- a/templates/allauth/elements/button.html
+++ b/templates/allauth/elements/button.html
@@ -1,0 +1,31 @@
+{% load allauth %}
+{% comment %} djlint:off {% endcomment %}
+<{% if attrs.href %}a href="{{ attrs.href }}"{% else %}button{% endif %}
+{% if attrs.form %}form="{{ attrs.form }}"{% endif %}
+{% if attrs.id %}id="{{ attrs.id }}"{% endif %}
+{% if attrs.name %}name="{{ attrs.name }}"{% endif %}
+{% if attrs.type %}type="{{ attrs.type }}"{% endif %}
+{% if attrs.value %}value="{{ attrs.value }}"{% endif %}
+class="{% block class %}
+    btn
+    {% if "link" in attrs.tags %}btn-link
+    {% else %}
+      {% if "prominent" in attrs.tags %}btn-lg{% elif "minor" in attrs.tags %}btn-sm{% endif %}
+      btn-{% if 'outline' in attrs.tags %}outline-{% endif %}{% if "danger" in attrs.tags %}danger{% elif "secondary" in attrs.tags %}secondary{% elif "warning" in attrs.tags %}warning{% else %}primary{% endif %}
+    {% endif %}{% endblock %}">
+    {% if "tool" in attrs.tags %}
+    {% if "delete" in attrs.tags %}
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+  <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6Z"/>
+  <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1ZM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118ZM2.5 3h11V2h-11v1Z"/>
+    </svg>
+    {% elif "edit" in attrs.tags %}
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 16 16"><path fill="currentColor" d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793L14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708zm.646 6.061L9.793 2.5L3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.5.5 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11z"/></svg>
+    {% endif %}
+    {% endif %}
+
+{% if not "tool" in attrs.tags %}
+{% slot %}
+{% endslot %}
+{% endif %}
+</{% if attrs.href %}a{% else %}button{% endif %}>

--- a/templates/allauth/elements/button__entrance.html
+++ b/templates/allauth/elements/button__entrance.html
@@ -1,0 +1,6 @@
+{% extends "allauth/elements/button.html" %}
+{% load allauth %}
+{% block class %}
+    {{ block.super }}
+    w-100
+{% endblock %}

--- a/templates/allauth/elements/button_group.html
+++ b/templates/allauth/elements/button_group.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<div class="btn-group-vertical w-100" role="group">
+    {% slot %}
+    {% endslot %}
+</div>

--- a/templates/allauth/elements/field.html
+++ b/templates/allauth/elements/field.html
@@ -1,0 +1,78 @@
+{% load allauth %}
+{% if attrs.type == "checkbox" or attrs.type == "radio" %}
+    <div class="form-check mb-3">
+        <input {% if attrs.required %}required{% endif %}
+               name="{{ attrs.name }}"
+               class="form-check-input"
+               id="{{ attrs.id }}"
+               {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
+               {% if attrs.disabled %}disabled{% endif %}
+               type="{{ attrs.type }}">
+        <label class="form-check-label" for="{{ attrs.id }}">
+            {% slot label %}
+            {% endslot %}
+        </label>
+        {% if slots.help_text %}
+            <div class="form-text">
+                {% slot help_text %}
+                {% endslot %}
+            </div>
+        {% endif %}
+    </div>
+{% elif attrs.type == "textarea" %}
+    <div class="mb-3">
+        <label class="" for="{{ attrs.id }}">
+            {% slot label %}
+            {% endslot %}
+        </label>
+        <textarea {% if attrs.required %}required{% endif %}
+                  {% if attrs.rows %}rows="{{ attrs.rows }}"{% endif %}
+                  class="form-control"
+                  name="{{ attrs.name }}"
+                  {% if attrs.readonly %}readonly{% endif %}
+                  id="{{ attrs.id }}"
+                  {% if attrs.disabled %}disabled{% endif %}>{% slot value %}{% endslot %}</textarea>
+    </div>
+{% elif attrs.type == "hidden" %}
+    <input {% if attrs.required %}required{% endif %}
+           name="{{ attrs.name }}"
+           id="{{ attrs.id }}"
+           {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
+           type="hidden">
+{% else %}
+    <div class="{% if attrs.unlabeled %}form-floating{% endif %} mb-3">
+        {% if not attrs.unlabeled %}
+            <label class="" for="{{ attrs.id }}">
+                {% slot label %}
+                {% endslot %}
+            </label>
+        {% endif %}
+        <input {% if attrs.required %}required{% endif %}
+               name="{{ attrs.name }}"
+               {% if attrs.placeholder %}placeholder="{{ attrs.placeholder }}" {% elif attrs.unlabeled %}placeholder="{% slot label %}{% endslot %}"{% endif %}
+               class="{% if attrs.errors %}is-invalid{% endif %} form-control rounded-3"
+               id="{{ attrs.id }}"
+               {% if attrs.readonly %}readonly{% endif %}
+               {% if attrs.disabled %}disabled{% endif %}
+               {% if attrs.tabindex %}tabindex="{{ attrs.tabindex }}"{% endif %}
+               {% if attrs.style %}style="{{ attrs.style }}"{% endif %}
+               {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
+               {% if attrs.value is not None %}value="{{ attrs.value }}"{% endif %}
+               type="{{ attrs.type }}">
+        {% if attrs.unlabeled %}
+            <label class="" for="{{ attrs.id }}">
+                {% slot label %}
+                {% endslot %}
+            </label>
+        {% endif %}
+        {% if slots.help_text %}
+            <div class="form-text">
+                {% slot help_text %}
+                {% endslot %}
+            </div>
+        {% endif %}
+        {% if attrs.errors %}
+            {% for error in attrs.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+        {% endif %}
+    </div>
+{% endif %}

--- a/templates/allauth/elements/fields.html
+++ b/templates/allauth/elements/fields.html
@@ -1,0 +1,11 @@
+{% load allauth %}
+{% for bound_field in attrs.form %}
+    {% element field unlabeled=attrs.unlabeled name=bound_field.name type=bound_field.field.widget.input_type required=bound_field.field.required value=bound_field.value id=bound_field.auto_id errors=bound_field.errors placeholder=bound_field.field.widget.attrs.placeholder tabindex=bound_field.field.widget.attrs.tabindex autocomplete=bound_field.field.widget.attrs.autocomplete style=bound_field.field.widget.attrs.style %}
+        {% slot label %}
+            {{ bound_field.label }}
+        {% endslot %}
+        {% slot help_text %}
+            {{ bound_field.field.help_text }}
+        {% endslot %}
+    {% endelement %}
+{% endfor %}

--- a/templates/allauth/elements/form.html
+++ b/templates/allauth/elements/form.html
@@ -1,0 +1,14 @@
+{% load allauth %}
+{% for err in attrs.form.non_field_errors %}<div class="alert alert-danger">{{ err }}</div>{% endfor %}
+<form class="{% block form_class %}{% if not attrs.no_visible_fields %}card{% endif %}{% endblock %}"
+      method="{{ attrs.method }}"
+      action="{{ attrs.action }}">
+    {% if not attrs.no_visible_fields %}<div class="card-body">{% endif %}
+        {% slot body %}
+        {% endslot %}
+        {% if not attrs.no_visible_fields %}</div>{% endif %}
+    {% if not attrs.no_visible_fields %}<div class="card-footer">{% endif %}
+        {% slot actions %}
+        {% endslot %}
+        {% if not attrs.no_visible_fields %}</div>{% endif %}
+</form>

--- a/templates/allauth/elements/form__entrance.html
+++ b/templates/allauth/elements/form__entrance.html
@@ -1,0 +1,2 @@
+{% extends "allauth/elements/form.html" %}
+{% block form_class %}{% endblock %}

--- a/templates/allauth/elements/h1.html
+++ b/templates/allauth/elements/h1.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<h1 class="mt-4">
+    {% slot %}
+    {% endslot %}
+</h1>

--- a/templates/allauth/elements/h1__entrance.html
+++ b/templates/allauth/elements/h1__entrance.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<h1 class="fw-bold fs-2">
+    {% slot %}
+    {% endslot %}
+</h1>

--- a/templates/allauth/elements/h2__entrance.html
+++ b/templates/allauth/elements/h2__entrance.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<h2 class="fw-bold fs-5">
+    {% slot %}
+    {% endslot %}
+</h2>

--- a/templates/allauth/elements/img.html
+++ b/templates/allauth/elements/img.html
@@ -1,0 +1,5 @@
+<div class="text-center">
+    <img class="img-fluid"
+         src="{{ attrs.src }}"
+         {% if attrs.alt %}alt="{{ attrs.alt }}"{% endif %}>
+</div>

--- a/templates/allauth/elements/panel.html
+++ b/templates/allauth/elements/panel.html
@@ -1,0 +1,17 @@
+{% load allauth %}
+<div class="card mb-4">
+    <div class="card-body">
+        <h5 class="card-title">
+            {% slot title %}
+            {% endslot %}
+        </h5>
+        {% slot body %}
+        {% endslot %}
+    </div>
+    {% if slots.actions %}
+        <div class="card-footer">
+            {% slot actions %}
+            {% endslot %}
+        </div>
+    {% endif %}
+</div>

--- a/templates/allauth/elements/provider.html
+++ b/templates/allauth/elements/provider.html
@@ -1,0 +1,4 @@
+{% load allauth %}
+<a class="list-group-item"
+   title="{{ attrs.name }}"
+   href="{{ attrs.href }}">{{ attrs.name }}</a>

--- a/templates/allauth/elements/provider_list.html
+++ b/templates/allauth/elements/provider_list.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<div class="list-group">
+    {% slot %}
+    {% endslot %}
+</div>

--- a/templates/allauth/elements/table.html
+++ b/templates/allauth/elements/table.html
@@ -1,0 +1,5 @@
+{% load allauth %}
+<table class="table table-striped">
+    {% slot %}
+    {% endslot %}
+</table>

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,40 +20,42 @@
     {% url "account_signup" as signup_url %}
     {% url "account_logout" as logout_url %}
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
-      <div class="container-fluid">
-        <a class="navbar-brand" href="{{ grudge_cabinet_url }}">How to Hold a Grudge</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item">
-              <a
-                class="nav-link{% if request.path == grudge_cabinet_url %} active{% endif %}"
-                aria-current="page"
-                href="{{ grudge_cabinet_url }}"
-              >Grudge Cabinet</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link disabled" aria-current="page" href="#">Gratitude Cabinet</a>
-            </li>
-          </ul>
-          <ul class="navbar-nav d-flex">
-            {% if user.is_authenticated %}
-            <li class="nav-item">
-                <a class="nav-link{% if request.path == logout_url %} active{% endif %}" aria-current="page" href="{{ logout_url }}">Sign out</a>
-            </li>
-            {% else %}
-            <li class="nav-item">
-                <a class="nav-link{% if request.path == signup_url %} active{% endif %}" aria-current="page" href="{{ signup_url }}">Sign up</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link{% if request.path == login_url %} active{% endif %}" aria-current="page" href="{{ login_url }}">Sign in</a>
-            </li>
-            {% endif %}
-          </ul>
+        <div class="container-fluid">
+            <a class="navbar-brand" href="{{ grudge_cabinet_url }}">How to Hold a Grudge</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <li class="nav-item">
+                        <a
+                            class="nav-link{% if request.path == grudge_cabinet_url %} active{% endif %}"
+                            aria-current="page"
+                            href="{{ grudge_cabinet_url }}"
+                        >
+                        Grudge Cabinet
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link disabled" aria-current="page" href="#">Gratitude Cabinet</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav d-flex">
+                    {% if user.is_authenticated %}
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.path == logout_url %} active{% endif %}" aria-current="page" href="{{ logout_url }}">Sign out</a>
+                    </li>
+                    {% else %}
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.path == signup_url %} active{% endif %}" aria-current="page" href="{{ signup_url }}">Sign up</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.path == login_url %} active{% endif %}" aria-current="page" href="{{ login_url }}">Sign in</a>
+                    </li>
+                    {% endif %}
+                </ul>
+            </div>
         </div>
-      </div>
     </nav>
 
     <!-- Main Content Area -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,9 @@
 <body>
     <!-- Navigation Bar -->
     {% url "grudge_cabinet" as grudge_cabinet_url %}
+    {% url "account_login" as login_url %}
+    {% url "account_signup" as signup_url %}
+    {% url "account_logout" as logout_url %}
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
       <div class="container-fluid">
         <a class="navbar-brand" href="{{ grudge_cabinet_url }}">How to Hold a Grudge</a>
@@ -38,14 +41,14 @@
           <ul class="navbar-nav d-flex">
             {% if user.is_authenticated %}
             <li class="nav-item">
-              <a class="nav-link disabled" aria-current="page" href="#">Logout</a>
+                <a class="nav-link{% if request.path == logout_url %} active{% endif %}" aria-current="page" href="{{ logout_url }}">Sign out</a>
             </li>
             {% else %}
             <li class="nav-item">
-              <a class="nav-link disabled" aria-current="page" href="#">Register</a>
+                <a class="nav-link{% if request.path == signup_url %} active{% endif %}" aria-current="page" href="{{ signup_url }}">Sign up</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link disabled" aria-current="page" href="#">Login</a>
+              <a class="nav-link{% if request.path == login_url %} active{% endif %}" aria-current="page" href="{{ login_url }}">Sign in</a>
             </li>
             {% endif %}
           </ul>


### PR DESCRIPTION
- Move base template into a root `templates` directory
- Add links to register, login, logout pages in navbar
- Style register, login, logout, and forgot password pages
- Style allauth form widgets to use Bootstrap classes